### PR TITLE
fix scary comment

### DIFF
--- a/scripting/expose-round-state.sp
+++ b/scripting/expose-round-state.sp
@@ -97,7 +97,7 @@ public void OnPluginEnd()
 }
 
 ///////////////////////
-// CORE PLUGIN LOGIC //
+// core plugin logic (please keep scary comments lower case...) //
 ///////////////////////
 void ERS_MainLogic(Socket socket, const char[] receiveData)
 {


### PR DESCRIPTION
Really not a fan of using uppercase comments, it may scare off future developers from wanting to contribute to this project. I would also highly recommend creating some form of documentation that a developer can read so they can properly understand the coding guidelines and branching structure for future contributions.

- Donna